### PR TITLE
Allow river to use existing index/alias

### DIFF
--- a/src/main/java/com/github/lbroudoux/elasticsearch/river/s3/river/S3River.java
+++ b/src/main/java/com/github/lbroudoux/elasticsearch/river/s3/river/S3River.java
@@ -157,8 +157,11 @@ public class S3River extends AbstractRiverComponent implements River{
       if (logger.isInfoEnabled()){
          logger.info("Starting amazon s3 river scanning");
       }
-      try{
-         client.admin().indices().prepareCreate(indexName).execute().actionGet();
+      try {
+         // Create the index if it doesn't exist
+         if (!client.admin().indices().prepareExists(indexName).execute().actionGet().isExists()) {
+            client.admin().indices().prepareCreate(indexName).execute().actionGet();
+         }
       } catch (Exception e) {
          if (ExceptionsHelper.unwrapCause(e) instanceof IndexAlreadyExistsException){
             // that's fine.


### PR DESCRIPTION
Updating river plugin to not fail if using existing alias/index for indexing from S3
